### PR TITLE
Support asymmetric sanitization

### DIFF
--- a/lib/json2xml.js
+++ b/lib/json2xml.js
@@ -76,7 +76,7 @@ ToXml.prototype.openTag = function(key) {
 }
 ToXml.prototype.addAttr = function(key, val) {
     if (this.options.sanitize) {
-        val = sanitizer.sanitize(val);
+        val = sanitizer.sanitize(val, false, true);
     }
     this.xml += ' ' + key + '="' + val + '"';
 }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -12,13 +12,32 @@
  *      "       &quot;
  *      '       &apos;
  */
-var chars = {
+// used for body text
+var charsEscape = {
     '&': '&amp;',
     '#': '&#35;',
     '<': '&lt;',
     '>': '&gt;',
-    '(': '&#40;',
-    ')': '&#41;',
+    "\u001F": "&#31;"
+};
+
+var charsUnescape = {
+    '&amp;': '&',
+    '&#35;': '#',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&#40;': '(',
+    '&#41;': ')',
+    '&quot;': '"',
+    '&apos;': "'",
+    "&#31;": "\u001F"
+};
+
+// used in attribute values
+var charsAttrEscape = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
     '"': '&quot;',
     "'": '&apos;'
 };
@@ -27,17 +46,17 @@ function escapeRegExp(string) {
     return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
 }
 
-exports.sanitize = function sanitize(value, reverse) {
+// sanitize body text
+exports.sanitize = function sanitize(value, reverse, attribute) {
     if (typeof value !== 'string') {
         return value;
     }
 
-    Object.keys(chars).forEach(function(key) {
-        if (reverse) {
-            value = value.replace(new RegExp(escapeRegExp(chars[key]), 'g'), key);
-        } else {
-            value = value.replace(new RegExp(escapeRegExp(key), 'g'), chars[key]);
-        }
+    var chars = reverse ? charsUnescape : (attribute ? charsAttrEscape : charsEscape);
+    var keys = Object.keys(chars);
+    
+    keys.forEach(function(key) {
+        value = value.replace(new RegExp(escapeRegExp(key), 'g'), chars[key]);
     });
 
     return value;

--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -60,6 +60,7 @@ function endElement(name) {
             currentObject[textNodeName()] = currentObject[textNodeName()].trim()
         }
 
+        // node-expat already reverse sanitizes it whether we like it or not
         //if (options.sanitize) {
         //    currentObject[textNodeName()] = sanitizer.sanitize(currentObject[textNodeName()], true);
         //}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xml2json",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Converts xml to json and vice-versa, using node-expat.",
   "repository": "git://github.com/buglabs/node-xml2json.git",
   "license": "MIT",


### PR DESCRIPTION
This allows us to deal with node-expat properly, which does not properly sanitize and unsanitize symmetrically. This changes allows us to do true round-trip xml to json conversions.